### PR TITLE
38 itn uptime analyzer cronjob

### DIFF
--- a/block-producers-uptime/templates/cronjob.yaml
+++ b/block-producers-uptime/templates/cronjob.yaml
@@ -31,21 +31,17 @@ spec:
               {{- end }}
             volumeMounts:
               {{- with .Values.deployment.secrets.credentialFile }}
-              {{- if and .dir .content .name }}
-              - name:  {{ .Release.Name }}-credential-file
+              - name:  {{ .releaseName }}-credential-file
                 mountPath: {{ .dir | quote }}
-              {{- end }}
               {{- end }}
           volumes:
             {{- with .Values.deployment.secrets.credentialFile }}
-            {{- if and .dir .content .name }}
-            - name: {{ .Release.Name }}-credential-file
+            - name: {{ .releaseName }}-credential-file
               secret:
-                secretName: {{ .Release.Name }}
+                secretName: {{ .releaseName }}
                 defaultMode: 0600
                 items:
-                  - key: {{ .Values.deployment.secrets.credentialFile.name }}
-                    path: {{ .Values.deployment.secrets.credentialFile.name }}.json
-            {{- end }}
+                  - key: {{ .name }}
+                    path: {{ .name }}.json
             {{- end }}
           restartPolicy: OnFailure

--- a/block-producers-uptime/templates/deployment.yaml
+++ b/block-producers-uptime/templates/deployment.yaml
@@ -42,20 +42,16 @@ spec:
             {{- end }}
           volumeMounts:
             {{- with .Values.deployment.secrets.credentialFile }}
-            {{- if and .dir .content .name }}
-            - name:  {{ .Release.Name }}-credential-file
+            - name:  {{ .releaseName }}-credential-file
               mountPath: {{ .dir | quote }}
-            {{- end }}
             {{- end }}
       volumes:
         {{- with .Values.deployment.secrets.credentialFile }}
-        {{- if and .dir .content .name }}
-        - name: {{ .Release.Name }}-credential-file
+        - name: {{ .releaseName }}-credential-file
           secret:
-            secretName: {{ .Release.Name }}
+            secretName: {{ .releaseName }}
             defaultMode: 0600
             items:
-              - key: {{ .Values.deployment.secrets.credentialFile.name }}
-                path: {{ .Values.deployment.secrets.credentialFile.name }}.json
-        {{- end }}
+              - key: {{ .name }}
+                path: {{ .name }}.json
         {{- end }}

--- a/block-producers-uptime/values.yaml
+++ b/block-producers-uptime/values.yaml
@@ -21,9 +21,6 @@ service:
   port: 8080
   externalTrafficPolicy: Local
 
-analyzer:
-  image:
-
 ingress:
   class: alb
   annotations: {}


### PR DESCRIPTION
A cronjob that starts a pod every noon and midnight to run `itn_uptime_analyzer`.

It uses the same image as `block_producers_uptime` only difference being that it overrides the default command.

Closes #38