### PR TITLE
move annotations out of conditional so it would always be included

### DIFF
--- a/node-stats-collector/templates/deployment.yaml
+++ b/node-stats-collector/templates/deployment.yaml
@@ -13,14 +13,14 @@ spec:
       {{- include "node-stats-collector.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.nodestats.metrics.enabled }}
-      prometheus.io/scrape: 'true'
-      prometheus.io/port: {{ .Values.service.port | quote }}
-      prometheus.io/path: '/metrics'
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: {{ .Values.service.port | quote }}
+        prometheus.io/path: '/metrics'
       {{- end }}
 
       labels:


### PR DESCRIPTION
Annotations were only included if podAnnotations had values. Adding additional prometheus annotations without podAnnotatations being defined made impossible to place prometheus annotations under `annotations`. They would become orphans 🌚