### PR TITLE
node-stats-collector - remove variables that aren't used

### DIFF
--- a/node-stats-collector/templates/deployment.yaml
+++ b/node-stats-collector/templates/deployment.yaml
@@ -56,14 +56,6 @@ spec:
               value: https://{{ .Values.nodestats.endpoint }}
             - name: OPENSEARCH_INDEX
               value: {{ .Values.nodestats.index }}
-            {{- if .Values.nodestats.metrics.enabled }}
-            - name: AXUM_HTTP_REQUESTS_TOTAL
-              value: node_stats_collector_requests_total
-            - name: AXUM_HTTP_REQUESTS_DURATION_SECONDS
-              value: node_stats_collector_requests_duration_seconds
-            - name: AXUM_HTTP_REQUESTS_PENDING
-              value: node_stats_collector_requests_pending
-            {{- end }}
             {{- if .Values.extraEnvVars }}
             {{- toYaml .Values.extraEnvVars | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
this variables are needed during application build time. Passing them during runtime has no effect therefore they should be removed