### PR TITLE
119 - Mina Daemon Refactor Snark Worker logic

### DIFF
--- a/mina-daemon/README.md
+++ b/mina-daemon/README.md
@@ -149,6 +149,8 @@ Parameter | Description | Default
 `node.secrets.walletPassword` | Password for wallet keypair | ` `
 `node.secrets.walletKey` | Private wallet keypair key | ` `
 `node.secrets.walletPub` | Public wallet keypair key | ` `
+`node.daemonAddress` | Snark Coordinator Daemon Address. Require `node.walletKeys.enabled: false` | localhost:8301
+`node.shutdownOnDisconnect` | Shutdown Snark Worker if disconnect. Require `node.walletKeys.enabled: false` | false
 `serviceAccount.annotations` | Custom Annotations for the service account | `{}`
 `podAnnotations` | Custom Annotations for the pod | `{}`
 `ingress.enabled` | Enable Ingress | `false`

--- a/mina-daemon/templates/deployment.yaml
+++ b/mina-daemon/templates/deployment.yaml
@@ -81,7 +81,19 @@ spec:
           {{ if .Values.deployment.customEntrypoint.enabled -}}
           command: [{{ .Values.deployment.customEntrypoint.entrypoint }}]
           {{- end }}
-          args: [ "daemon",
+          args: [
+
+            {{- if and (not .Values.node.walletKeys.enabled) .Values.node.daemonMode.snarkWorker }}
+            "internal", "snark-worker",
+            {{- if .Values.node.daemonAddress }}
+            "--daemon-address", {{ .Values.node.daemonAddress | quote }},
+            {{- end }}
+            {{- if .Values.node.proofLevel }}
+            "--proof-level", {{ .Values.node.proofLevel | quote }},
+            {{- end }}
+            {{- else }}
+
+            "daemon",
             {{- if .Values.deployment.uptime.enabled }}
             "--uptime-url", {{ .Values.deployment.uptime.url | quote }},
             "--uptime-submitter-key", "/root/mina-keys/{{ .Values.node.name }}-key",
@@ -299,6 +311,8 @@ spec:
             "--work-selection", {{ .Values.node.workSelection | quote }},
             {{- end }}
             "--log-json"
+
+            {{- end }}
           ]
           env:
             - name: MINA_NETWORK

--- a/mina-daemon/templates/service-daemon.yaml
+++ b/mina-daemon/templates/service-daemon.yaml
@@ -28,6 +28,9 @@ spec:
     - name: tcp-p2p
       port: {{ .Values.node.ports.p2p }}
       targetPort: external-port
+    - name: client
+      port: {{ .Values.node.ports.client }}
+      targetPort: client-port
     {{- if .Values.node.metrics.enabled }}
     - name: metrics-port
       port: {{ .Values.node.metrics.port }}

--- a/mina-daemon/values.yaml
+++ b/mina-daemon/values.yaml
@@ -107,6 +107,11 @@ node:
     walletPub: ""
     discoveryLibp2p: ""
     discoveryLibp2pPeerid: ""
+  # Snark Worker specific settings - Note that walletKeys.enabled should be set to false. 
+  daemonAddress: localhost:8301
+  shutdownOnDisconnect: false
+
+
   extraEnvVars: {}
     # - name: FOO
     #   value: FOO
@@ -115,7 +120,6 @@ node:
     #     secretKeyRef:
     #       name: mySecret
     #       key: bar
-
 serviceAccount:
   annotations: {}
 


### PR DESCRIPTION
This PR aims to refactor the Snark Worker Logic without introducing breaking changes.
This is required for the ITN, and the deadline is approaching rapidly.

Snark Worker on Berkeley use this command to run
`mina internal snark-worker -proof-level  full  -shutdown-on-disconnect false -daemon-address <snark coordinator IP and port>`

As we gain more knowledge in running Mina components, I would suggest to review in depth and release a new version once the HF is released