### PR TITLE
Add Pod Rotation Controller Helm Chart

### DIFF
--- a/pod-rotation-controller/.helmignore
+++ b/pod-rotation-controller/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/pod-rotation-controller/Chart.yaml
+++ b/pod-rotation-controller/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: pod-rotation-controller
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/pod-rotation-controller/README.md
+++ b/pod-rotation-controller/README.md
@@ -1,0 +1,61 @@
+# Pod Rotation Controller
+
+pod-rotation-controller is a tools that rotates the oldest pod based on a Regex Pattern and a schedule.
+
+## TL;DR
+
+```console
+git clone https://github.com/MinaFoundation/helm-charts
+cd helm-charts/pod-rotation-controller
+helm install RELEASE_NAME ./ --namespace NAMESPACE
+```
+
+## Prerequisites
+
+- Kubernetes 1.12+
+- Helm 3.1.0
+
+## Installing the Chart
+
+To install the chart with the release name `RELEASE_NAME`:
+
+```console
+helm install RELEASE_NAME ./ --namespace NAMESPACE
+```
+
+The command deploys pod-rotation-controller on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `RELEASE_NAME` deployment:
+
+```console
+helm delete RELEASE_NAME
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Parameters
+
+| Name                                     | Description                                         | Value                       |
+| ---------------------------------------- | --------------------------------------------------- | --------------------------- |
+| `image.repository`                       | pod-rotation-controller image name                  | `673156464838.dkr.ecr.us-west-2.amazonaws.com/github-actions-runner` |
+| `image.pullPolicy`                       | pod-rotation-controller image pull policy           | `IfNotPresent`              |
+| `image.pullSecrets`                      | Specify docker-registry secret names as an array    | `[]`                        |
+| `nameOverride`                           | String to partially override common.names.fullname   | ""                          |
+| `fullnameOverride`                       | String to fully override common.names.fullname       | ""                          |
+| `serviceAccount.create`                  | Enable the creation of a ServiceAccount for pod-rotation-controller pods | `true` |
+| `serviceAccount.annotations`             | Annotations for the created ServiceAccount          | {}                          |
+| `serviceAccount.name`                    | Name of the created ServiceAccount                   | ""                          |
+| `podAnnotations`                         | Annotations for pod-rotation-controller pods         | {}                          |
+| `podLabels`                              | Extra labels for pod-rotation-controller pods        | {}                          |
+| `podRegexPattern`                        | Regex pattern to match pods                          | ".*"                        |
+| `schedule`                               | Schedule to run pod rotation, runs every 6 hours     | "0 */6 * * *"               |
+| `restartPolicy`                          | Restart Policy when the job fails, can be OnFailure, Never, Always | "OnFailure" |
+| `podSecurityContext`                     | Set pod-rotation-controller Pod's Security Context   | {}                          |
+| `securityContext`                        | Set pod-rotation-controller Security Context          | {}                          |
+| `resources.limits`                      | The resources limits for the pod-rotation-controller container | {}                   |
+| `resources.requests`                    | The resources requests for the pod-rotation-controller container | {}                 |
+| `nodeSelector`                          | Node labels for pod assignment                       | {}                          |
+| `tolerations`                            | Tolerations for pod assignment                       | {}                          |
+| `affinity`                               | Affinity for pod assignment                          | {}                          |

--- a/pod-rotation-controller/scripts/pod-rotation-controller.sh
+++ b/pod-rotation-controller/scripts/pod-rotation-controller.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+regex_pattern="${POD_REGEX_PATTERN}"
+
+echo "The regex pattern is: $regex_pattern"
+
+if [ -z "$regex_pattern" ]; then
+    echo "The POD_REGEX_PATTERN environment variable is not set or is empty."
+    exit 1
+fi
+
+# Get a list of pods in the specified namespace with creation timestamps
+pod_list=$(kubectl get pods --sort-by='.metadata.creationTimestamp' -o json | jq -r ".items[] | select(.metadata.name | test(\"$regex_pattern\")) | .metadata.name")
+
+if [ -z "$pod_list" ]; then
+    echo "No pods matching the regex pattern '$regex_pattern' found in current namespace."
+    exit 1
+fi
+echo "Pod list matching the regex pattern:"
+echo $pod_list
+
+# Extract the first item from the list
+first_matching_pod=$(echo "$pod_list" | head -n 1)
+
+# Print the first matching pod
+echo "The following pod will be deleted:"
+echo "$first_matching_pod"
+
+# kubectl delete pod $first_matching_pod

--- a/pod-rotation-controller/templates/_helpers.tpl
+++ b/pod-rotation-controller/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "pod-rotation-controller.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "pod-rotation-controller.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "pod-rotation-controller.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "pod-rotation-controller.labels" -}}
+helm.sh/chart: {{ include "pod-rotation-controller.chart" . }}
+{{ include "pod-rotation-controller.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "pod-rotation-controller.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "pod-rotation-controller.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "pod-rotation-controller.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "pod-rotation-controller.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/pod-rotation-controller/templates/configmap.yaml
+++ b/pod-rotation-controller/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "pod-rotation-controller.fullname" . }}
+  labels:
+    {{- include "pod-rotation-controller.labels" . | nindent 4 }}
+data:
+  pod-rotation-controller.sh: |
+{{ .Files.Get "scripts/pod-rotation-controller.sh" | indent 4 }}

--- a/pod-rotation-controller/templates/cronjob.yaml
+++ b/pod-rotation-controller/templates/cronjob.yaml
@@ -1,0 +1,60 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "pod-rotation-controller.fullname" . }}
+  labels:
+    {{- include "pod-rotation-controller.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.schedule | quote }}
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          {{- with .Values.podAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 8 }}
+          {{- end }}
+          {{- with .Values.podLabels }}
+          labels:
+            {{- toYaml . | nindent 8 }}
+          {{- end }}
+        spec:
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 8 }}
+          {{- end }}
+          serviceAccountName: {{ include "pod-rotation-controller.serviceAccountName" . }}
+          securityContext:
+            {{- toYaml .Values.podSecurityContext | nindent 12 }}
+          containers:
+            - name: {{ .Chart.Name }}
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              command: ["/bin/sh", "-c"]
+              args: ["/scripts/pod-rotation-controller.sh"]
+              env:
+                - name: POD_REGEX_PATTERN
+                  value: "{{ .Values.podRegexPattern }}"
+              {{- with .Values.nodeSelector }}
+              resources:
+                {{- toYaml .Values.resources | nindent 16 }}
+              nodeSelector:
+                {{- toYaml . | nindent 12 }}
+              {{- end }}
+              {{- with .Values.affinity }}
+              affinity:
+                {{- toYaml . | nindent 12 }}
+              {{- end }}
+              {{- with .Values.tolerations }}
+              tolerations:
+                {{- toYaml . | nindent 12 }}
+              {{- end }}
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+          restartPolicy: {{ .Values.restartPolicy }}
+          volumes:
+            - name: scripts
+              configMap:
+                name: {{ include "pod-rotation-controller.fullname" . }}
+                defaultMode: 0755

--- a/pod-rotation-controller/templates/role.yaml
+++ b/pod-rotation-controller/templates/role.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "pod-rotation-controller.serviceAccountName" . }}
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["list", "delete"]

--- a/pod-rotation-controller/templates/rolebinding.yaml
+++ b/pod-rotation-controller/templates/rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "pod-rotation-controller.serviceAccountName" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "pod-rotation-controller.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "pod-rotation-controller.serviceAccountName" . }}
+  apiGroup: rbac.authorization.k8s.io

--- a/pod-rotation-controller/templates/serviceaccount.yaml
+++ b/pod-rotation-controller/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "pod-rotation-controller.serviceAccountName" . }}
+  labels:
+    {{- include "pod-rotation-controller.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/pod-rotation-controller/values.yaml
+++ b/pod-rotation-controller/values.yaml
@@ -1,0 +1,128 @@
+## Mina Foundation image version
+##
+## @param image.repository [default:  673156464838.dkr.ecr.us-west-2.amazonaws.com/github-actions-runner] pod-rotation-controller image name
+## @param image.pullPolicy pod-rotation-controller image pull policy
+## @param image.tag [default: default-2023.09.26] tag name
+image:
+  repository: 673156464838.dkr.ecr.us-west-2.amazonaws.com/github-actions-runner
+  pullPolicy: IfNotPresent
+  tag: "default-2023.09.26"
+
+## @param imagePullSecrets Specify docker-registry secret names as an array
+##
+imagePullSecrets: []
+## String to partially override pod-rotation-controller template (will maintain the release name)
+## @param nameOverride String to partially override common.names.fullname
+##
+nameOverride: ""
+## String to fully override pod-rotation-controller template
+## @param fullnameOverride String to fully override common.names.fullname
+##
+fullnameOverride: ""
+
+## Specifies whether a ServiceAccount should be created
+##
+## @param serviceAccount.create Enable the creation of a ServiceAccount for pod-rotation-controller pods
+## @param serviceAccount.annotations Name of the created ServiceAccount
+## @param serviceAccount.name Annotations for the created ServiceAccount
+##
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+## Annotations for server pods.
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+## @param podAnnotations  Annotations for pod-rotation-controller pods
+##
+podAnnotations: {}
+
+## Pod extra labels
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+##
+## @param podLabels  Extra labels for pod-rotation-controller pods
+##
+podLabels: {}
+
+## Pod Regex Pattern
+##
+## @param podRegexPattern [default: .*] Regex pattern to match pods
+##
+podRegexPattern: ".*"
+
+## Schedule
+##
+## @param schedule [default: 0 */6 * * *] Schedule to run pod rotation, runs every 6 hours
+##
+schedule: "0 */6 * * *"
+
+## Restart Policy
+##
+## @param restartPolicy [default: OnFailure] Restart Policy when the job fails, can be OnFailure, Never, Always
+##
+restartPolicy: "OnFailure"
+
+## Pod podSecurityContext
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+##
+## @param podSecurityContext  Set pod-rotation-controller Pod's Security Context
+##
+podSecurityContext: {}
+  # fsGroup: 2000
+
+## securityContext
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+##
+## @param securityContext  Set pod-rotation-controller Security Context
+##
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+## pod-rotation-controller resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  ##
+  ## @param resources.limits  The resources limits for the pod-rotation-controller container
+  ##
+  limits: {}
+  #   cpu: 200m
+  #   memory: 256Mi
+  ##
+  ## @param resources.requests  The resources requests for the pod-rotation-controller container
+  ##
+  requests: {}
+  #   cpu: 200m
+  #   memory: 10Mi
+
+## Node labels for pod assignment. Evaluated as a template.
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+## @param nodeSelector  Node labels for pod assignment
+##
+nodeSelector: {}
+
+## Tolerations for pod assignment. Evaluated as a template.
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+## @param tolerations  Tolerations for pod assignment
+##
+tolerations: []
+
+## Affinity for pod assignment. Evaluated as a template.
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+## Note: podAffinityPreset, podAntiAffinityPreset, and nodeAffinityPreset will be ignored when it's set
+##
+## @param affinity  Affinity for pod assignment
+##
+affinity: {}


### PR DESCRIPTION
This is a Helm Chart which aim to delete the oldest pod based on a regex pattern and a schedule
It is essentially used to rotate periodically pods in the punkpoll network to mitigate memory leaks, we can use it anywhere we run mina components