### PR TITLE
PM-475 - Removing set -euo pipefail as script need to be fault tolerant

### DIFF
--- a/mina-archive/scripts/missing-blocks-guardian.sh
+++ b/mina-archive/scripts/missing-blocks-guardian.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -euo pipefail
 
 # This script is adapted from https://github.com/MinaProtocol/mina/blob/develop/src/app/rosetta/download-missing-blocks.sh
 # It is used to populate a postgres database with missing precomputed archiveDB blocks


### PR DESCRIPTION
The script is expected to throw some errors if redeployed with an existing database.
This currently leads the archive pod to crashloop.
The only requirement is the have the required environment variables which are tested within the script already 