### PR TITLE
PM 524 Refactor Archive Node Logic to decouple missing blocks guardian from initFromDump

### DIFF
--- a/mina-archive/templates/configmap-missing-blocks-guardian.yaml
+++ b/mina-archive/templates/configmap-missing-blocks-guardian.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.archive.initFromDump }}
+{{- if .Values.archive.missingBlocksGuardian.enabled }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/mina-archive/templates/deployment.yaml
+++ b/mina-archive/templates/deployment.yaml
@@ -69,7 +69,7 @@ spec:
 {{- $postgresHost := tpl .Values.archive.postgresHost . }}
 {{- $data := dict "postgresHost" $postgresHost "healthcheck" $.Values.healthcheck }}
 {{- include "healthcheck.archive.allChecks" $data | indent 10 }}
-        {{- if .Values.archive.initFromDump.enabled }}
+        {{- if .Values.archive.missingBlocksGuardian.enabled }}
         - name: missing-blocks-guardian
           image: {{ .Values.archive.image }}
           env:
@@ -83,14 +83,12 @@ spec:
               value: {{ .Values.archive.ports.postgres | quote }}
             - name: DB_NAME
               value: {{ .Values.postgresql.auth.database | quote }}
-            - name: ARCHIVE_DUMP_URL
-              value: {{ .Values.archive.initFromDump.archiveDumpURL | quote }}
             - name: MINA_NETWORK
               value: {{ .Values.archive.testnet | quote }}
             - name: PRECOMPUTED_BLOCKS_URL
-              value: {{ .Values.archive.initFromDump.precomputedBlocksURL| quote }}
+              value: {{ .Values.archive.missingBlocksGuardian.precomputedBlocksURL| quote }}
             - name: MISSING_BLOCKS_GUARDIAN_WAIT_TIME
-              value: {{ .Values.archive.initFromDump.missingBlocksGuardianWaitTime| quote }}
+              value: {{ .Values.archive.missingBlocksGuardian.waitTime| quote }}
           command: ["bash", "-c"]
           args:
             - 'sleep ${MISSING_BLOCKS_GUARDIAN_WAIT_TIME} && bash /scripts/missing-blocks-guardian.sh'
@@ -113,7 +111,7 @@ spec:
           configMap:
             name: {{ .Release.Name }}-runtime-config
         {{- end }}
-        {{- if .Values.archive.initFromDump.enabled }}
+        {{- if .Values.archive.missingBlocksGuardian.enabled }}
         - name: {{ .Release.Name }}-missing-blocks-guardian
           configMap:
             name: {{ .Release.Name }}-missing-blocks-guardian

--- a/mina-archive/values.yaml
+++ b/mina-archive/values.yaml
@@ -20,9 +20,10 @@ archive:
   initFromDump:
     enabled: false
     archiveDumpURL: https://storage.googleapis.com/mina-archive-dumps
+  missingBlocksGuardian:
+    enabled: false
     precomputedBlocksURL: https://storage.googleapis.com/mina_network_block_data
-    missingBlocksGuardianWaitTime: 1800  # 30 minutes
-
+    waitTime: 1800  # 30 minutes
   service:
     labels: {}
     annotations: {}


### PR DESCRIPTION
- PM-524 - Refactor Archive Node Logic to decouple missing blocks guardian from initFromDump
