### PR TITLE
PM-1285 - Enable generation of libp2p keys at runtime

### DIFF
--- a/mina-daemon/README.md
+++ b/mina-daemon/README.md
@@ -70,6 +70,7 @@ Parameter | Description
 `node.secrets.libp2pPassword` | Password for libp2p keypair | ` `
 `node.secrets.discoveryLibp2p` | Private libp2p keypair key | ` `
 `node.secrets.discoveryLibp2pPeerid` | Public libp2p keypair key | ` `
+`node.libp2pKeys.create` | If set to `true`, libp2p keypair is created at runtime | `false`
 
 ### Optional Settings
 

--- a/mina-daemon/scripts/entrypoint.sh
+++ b/mina-daemon/scripts/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Export the MINA_LIBP2P_PASS environment variable if MINA_LIBP2P_PASS_PATH is set
+if [ -n "$MINA_LIBP2P_PASS_PATH" ]; then
+    if [ -f "$MINA_LIBP2P_PASS_PATH" ]; then
+        export MINA_LIBP2P_PASS=$(cat "$MINA_LIBP2P_PASS_PATH")
+    fi
+fi
+
+# Start the mina daemon
+echo "Starting mina daemon with arguments: ${@}"
+mina "${@}"

--- a/mina-daemon/scripts/generate-libp2p-keys.sh
+++ b/mina-daemon/scripts/generate-libp2p-keys.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+if [ -z "$MINA_LIBP2P_PRIV_KEYPATH" ]; then
+    echo "The MINA_LIBP2P_PRIV_KEYPATH environment variable is not set or is empty."
+    exit 1
+fi
+
+# Function to generate a random password
+generate_password() {
+    password=$(openssl rand -base64 64 | tr -dc 'a-zA-Z0-9' | head -c 64)
+    echo "$password"
+}
+
+generate_libp2p_keys() {
+    mina libp2p generate-keypair -privkey-path ${MINA_LIBP2P_PRIV_KEYPATH}
+    chmod -R 0700 "$(dirname ${MINA_LIBP2P_PRIV_KEYPATH})"
+    chmod -R 0600 ${MINA_LIBP2P_PRIV_KEYPATH}*
+}
+
+# Generate the libp2p keypair password
+export MINA_LIBP2P_PASS=$(generate_password)
+
+# Write the password to disk
+echo "${MINA_LIBP2P_PASS}" > "${MINA_LIBP2P_PRIV_KEYPATH}.password"
+
+# Generate the libp2p keypair
+generate_libp2p_keys $MINA_LIBP2P_PRIV_KEYPATH

--- a/mina-daemon/templates/configmap.yaml
+++ b/mina-daemon/templates/configmap.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.deployment.storeBlocks.aws.enabled }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -9,10 +8,17 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 data:
+  entrypoint.sh: |-
+{{ (.Files.Get "scripts/entrypoint.sh") | indent 4 }}
+{{- if .Values.deployment.storeBlocks.aws.enabled }}
   gsutil-impersonator.sh: |-
 {{ (.Files.Get "scripts/gsutil-impersonator.sh") | indent 4 }}
   gcloud-impersonator.sh: |-
 {{ (.Files.Get "scripts/gcloud-impersonator.sh") | indent 4 }}
   s3-blocks-uploader.sh: |-
 {{ (.Files.Get "scripts/s3-blocks-uploader.sh") | indent 4 }}
+{{- end }}
+{{- if .Values.node.libp2pKeys.create }}
+  generate-libp2p-keys.sh: |-
+{{ (.Files.Get "scripts/generate-libp2p-keys.sh") | indent 4 }}
 {{- end }}

--- a/mina-daemon/templates/deployment.yaml
+++ b/mina-daemon/templates/deployment.yaml
@@ -31,6 +31,20 @@ spec:
       serviceAccountName: {{ .Release.Name }}
       initContainers:
         {{ if .Values.node.libp2pKeys.enabled -}}
+        {{ if .Values.node.libp2pKeys.create -}}
+        - name: generate-libp2p-keys
+          image: {{ .Values.deployment.image }}
+          command: ["/bin/sh", "/scripts/generate-libp2p-keys.sh"]
+          env:
+            - name: MINA_LIBP2P_PRIV_KEYPATH
+              value: /root/libp2p-keys/{{ .Values.node.name }}-libp2p
+          volumeMounts:
+            - name: {{ .Release.Name }}-scripts
+              mountPath: /scripts/generate-libp2p-keys.sh
+              subPath: generate-libp2p-keys.sh
+            - name: {{ .Release.Name }}-generated-libp2p-keys
+              mountPath: /root/libp2p-keys
+        {{- else -}}
         - name: fix-libp2p-perms
           image: busybox:latest
           command:
@@ -42,6 +56,7 @@ spec:
               mountPath: /libp2p-keys
             - name: {{ .Release.Name }}-fixed-libp2p-keys
               mountPath: /root/libp2p-keys
+        {{- end }}
         {{- end }}
         {{ if .Values.node.walletKeys.enabled -}}
         - name: fix-mina-perms
@@ -104,11 +119,8 @@ spec:
               ephemeral-storage: {{ .Values.resources.ephemeralStorageRequest }}
               {{- end }}
           image: {{ .Values.deployment.image }}
-          {{ if .Values.deployment.customEntrypoint.enabled -}}
-          command: [{{ .Values.deployment.customEntrypoint.entrypoint }}]
-          {{- end }}
+          command: ["/bin/sh", "/scripts/entrypoint.sh"]
           args: [
-
             {{- if and (not .Values.node.walletKeys.enabled) .Values.node.daemonMode.snarkWorker }}
             "internal", "snark-worker",
             {{- if .Values.node.daemonAddress }}
@@ -118,7 +130,6 @@ spec:
             "--proof-level", {{ .Values.node.proofLevel | quote }},
             {{- end }}
             {{- else }}
-
             "daemon",
             {{- if .Values.deployment.uptime.enabled }}
             "--uptime-url", {{ .Values.deployment.uptime.url | quote }},
@@ -366,11 +377,16 @@ spec:
             - name: DAEMON_EXTERNAL_PORT
               value: {{ .Values.node.ports.p2p | quote }}
             {{- if .Values.node.libp2pKeys.enabled }}
+            {{- if .Values.node.libp2pKeys.create }}
+            - name: MINA_LIBP2P_PASS_PATH
+              value: /root/libp2p-keys/{{ .Values.node.name }}-libp2p.password
+            {{- else }}
             - name: MINA_LIBP2P_PASS
               valueFrom:
                 secretKeyRef:
                   name: {{ .Release.Name }}
                   key: "libp2p-password"
+            {{- end }}
             {{- end }}
             {{- if .Values.node.walletKeys.enabled }}
             - name: MINA_PRIVKEY_PASS
@@ -408,9 +424,17 @@ spec:
 {{- include "healthcheck.node.allChecks" $data | indent 10 }}
           imagePullPolicy: Always
           volumeMounts:
-            {{- if .Values.node.libp2pKeys.enabled }}
+            - name: {{ .Release.Name }}-scripts
+              mountPath: /scripts/entrypoint.sh
+              subPath: entrypoint.sh
+            {{ if .Values.node.libp2pKeys.enabled -}}
+            {{ if .Values.node.libp2pKeys.create -}}
+            - name: {{ .Release.Name }}-generated-libp2p-keys
+              mountPath: /root/libp2p-keys
+            {{- else -}}
             - name: {{ .Release.Name }}-fixed-libp2p-keys
               mountPath: /root/libp2p-keys
+            {{- end }}
             {{- end }}
             {{- if .Values.node.walletKeys.enabled }}
             - name: {{ .Release.Name }}-fixed-mina-keys
@@ -503,6 +527,10 @@ spec:
           emptyDir: {}
         {{- end }}
         {{- if .Values.node.libp2pKeys.enabled }}
+        {{- if .Values.node.libp2pKeys.create }}
+        - name: {{ .Release.Name }}-generated-libp2p-keys
+          emptyDir: {}
+        {{- else }}
         - name: {{ .Release.Name }}-mounted-libp2p-keys
           secret:
             secretName: {{ .Release.Name }}
@@ -514,6 +542,7 @@ spec:
                 path: {{ .Values.node.name }}-libp2p.peerid
         - name: {{ .Release.Name }}-fixed-libp2p-keys
           emptyDir: {}
+        {{- end }}
         {{- end }}
         {{- if or .Values.deployment.storeBlocks.gcp.enabled .Values.deployment.storeBlocks.aws.enabled }}
         - name: {{ .Release.Name }}-gcloud-keyfile
@@ -529,12 +558,10 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Release.Name }}-precomputed-blocks
         {{- end }}
-        {{- if .Values.deployment.storeBlocks.aws.enabled }}
         - name: {{ .Release.Name }}-scripts
           configMap:
             name: {{ .Release.Name }}-scripts
             defaultMode: 0755
-        {{- end }}
   {{- if .Values.updateStrategy  }}
   strategy: {{- toYaml .Values.updateStrategy | nindent  4 }}
   {{- end }}

--- a/mina-daemon/templates/secret.yaml
+++ b/mina-daemon/templates/secret.yaml
@@ -5,11 +5,13 @@ metadata:
   name: {{ .Release.Name }}
 data:
   wallet-password: {{ .Values.node.secrets.walletPassword | b64enc }}
-  libp2p-password: {{ .Values.node.secrets.libp2pPassword | b64enc }}
   {{ .Values.node.name }}-key: {{ .Values.node.secrets.walletKey | b64enc }}
   {{ .Values.node.name }}-key.pub: {{ .Values.node.secrets.walletPub | b64enc }}
+  {{- if and .Values.node.libp2pKeys.enabled (not .Values.node.libp2pKeys.create) }}
+  libp2p-password: {{ .Values.node.secrets.libp2pPassword | b64enc }}
   {{ .Values.node.name }}-libp2p: {{ .Values.node.secrets.discoveryLibp2p | b64enc }}
   {{ .Values.node.name }}-libp2p.peerid: {{ .Values.node.secrets.discoveryLibp2pPeerid | b64enc }}
+  {{- end }}
   {{- if or .Values.deployment.storeBlocks.gcp.enabled .Values.deployment.storeBlocks.aws.enabled }}
   gcloud-keyfile: {{ .Values.deployment.storeBlocks.gcp.keyfile | b64enc }}
   {{- end }}

--- a/mina-daemon/values.yaml
+++ b/mina-daemon/values.yaml
@@ -2,9 +2,6 @@ deployment:
   testnet: "berkeley"
   image: minaprotocol/mina-daemon:1.3.2beta2-release-2.0.0-05c2f73-bulseye-berkeley
   genesisLedgerURL:
-  customEntrypoint:
-    enabled: true
-    entrypoint: "mina"
   peerListURL: "https://storage.googleapis.com/seed-lists/berkeley_seeds.txt"
   uptime:
     enabled: false
@@ -106,6 +103,7 @@ node:
     address: staging-berkeley-archive:3086
   libp2pKeys:
     enabled: true
+    create: false
     legacy: false
   walletKeys:
     enabled: false
@@ -169,7 +167,7 @@ service:
 podAnnotations: {}
 
 updateStrategy:
-  type: RollingUpdate
+  type: Recreate
 
 resources:
   memoryRequest: "16.0Gi"


### PR DESCRIPTION
This PR enable the creation of libp2p key at runtime.
It is set to `false` by default to prevent breaking changes