### PR TITLE
PM-1429 fix init database and worker scripts

### DIFF
--- a/delegation-verify-coordinator/files/entrypoint_initdb.sh
+++ b/delegation-verify-coordinator/files/entrypoint_initdb.sh
@@ -1,24 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -x
 
-max_retries=10
-retries=0
-
-while [ $retries -lt $max_retries ]; do
-
-  invoke create-database
-
-  if [ $? -eq 0 ]; then # create-database was successful
-    invoke init-database
-    break
-  else
-    echo "Command invoke create database returned non-zero response"
-    exit 1
-  fi
-  
-  ((retries++))
-
-  sleep 6
-
-done
+invoke create-database
+invoke init-database

--- a/delegation-verify-coordinator/files/entrypoint_worker.sh
+++ b/delegation-verify-coordinator/files/entrypoint_worker.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Source credentials for AWS
+source /var/mina-delegation-verify-auth/.env
+
+/go/bin/submission_updater "$START_TIMESTAMP" "$END_TIMESTAMP"


### PR DESCRIPTION
this PR changes the following:
- initdb does not need retry mechanism
- worker image have changed as well as its arguments 