### PR TITLE
PM-1429 bring back worker CM as it's needed inside coordinator

### DIFF
--- a/delegation-verify-coordinator/templates/configmap_worker.yaml
+++ b/delegation-verify-coordinator/templates/configmap_worker.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-worker
+data:
+  entrypoint-worker.sh: |-
+{{ .Files.Get "files/entrypoint_worker.sh" | indent 4 }}


### PR DESCRIPTION
in previous cleanup commit I have removed config map template for worker entry point.
It appears it's still used and needs to come back