### PR TITLE
PM-1664 - Thirsty of better error management

### DIFF
--- a/mina-archive/values.yaml
+++ b/mina-archive/values.yaml
@@ -73,7 +73,6 @@ dbBootstrap:
   # -- SQL file urls to pre-download before executing the SQL file urls
   extraSqlFileUrls: []
     # - https://raw.githubusercontent.com/MinaProtocol/mina/develop/src/app/archive/zkapp_tables.sql
-    # - https://storage.googleapis.com/mina-archive-dumps
 
   # -- Execute SQL inline command before loading the SQL file urls
   # preCustomSql: SELECT session_user, current_database()


### PR DESCRIPTION
This PR bring a better error message handling when the remote files are not downloadable.

It also removes the deprecated commented lines in the `values.yaml` to avoid confusion.