### PR TITLE
PM-1666 remove AWS key/id as mandatory fields. Fix README

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: helm-docs-built
         args:
           # Comma separated list, no space
-          - --chart-to-generate=gpt-survey-summarizer,submission-report,mina-transactions-generator,mina-payouts-data-provider,mina-archive,redisinsight
+          - --chart-to-generate=gpt-survey-summarizer,submission-report,mina-transactions-generator,mina-payouts-data-provider,mina-archive,redisinsight,uptime-service-backend
 
           # The `./` makes it relative to the chart-search-root
           - --template-files=./README.md.gotmpl

--- a/uptime-service-backend/README.md
+++ b/uptime-service-backend/README.md
@@ -1,157 +1,101 @@
-# Uptime service backend
+# uptime-service-backend
 
-A backend service for delegation program where participating nodes report stats about their activity.
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
+A Helm chart for uptime-service-backend AKA Delegation Program Backend
 
-> **Note** Currently MF does not have chart repository. To install this chart i.e. with helmfile you need to reffer to it following ways:
+**Homepage:** <https://docs.minaprotocol.com/node-operators/foundation-delegation-program>
 
-```console
-# helmfile.yaml
-<..>
-releases:
-  - name: network_name
-    chart: git::ssh://git@github.com/MinaFoundation/helm-charts.git@uptime-service-backend?ref=main
-<..>
-```
+## Source Code
+
+* <https://github.com/MinaFoundation/uptime-service-backend/tree/main/src/delegation_backend>
 
 ## Prerequisites
 
-Before installing this Helm chart, you should have the following prerequisites:
+Before using this Helm chart, you should have the following prerequisites:
 
- - Access to Kubernetes cluster
- - Helm installed on your local machine
- - Basic knowledge of Kubernetes and Helm
- - Access to https://github.com/MinaFoundation/helm-charts
- - Optional: helmfile to install this chart
+- Access to Kubernetes cluster (If needed contact your friendly neighbourhood DevOps engineer)
+- Helm >= v3.14.3
+- (**Optional**) helmfile >= v0.162.0 to install this chart
 
 ## Installation
 
+> Note: **examples** can be found in the repository
+
 To install this Helm chart, the easiest is to create a helmfile.yaml with needed values and run:
-```bash
-$ helmfile template
-$ helmfile apply
- ```
+
+```
+helmfile template
+helmfile apply
+```
 
 Or use helmfile only to generate resources and apply them with kubectl like so:
 
-```bash
-$ helmfile template | kubectl -f -
 ```
-
-You can get some inspiration from helmfiles in `examples` folder.
+helmfile template | kubectl -f -
+```
 
 Verify that the chart is deployed successfully:
 
-```bash
-helmfile status #although kubectl probably would give better insights.
+> Note: `kubectl` is a better suited tool for this
+
+```
+helmfile status
 ```
 
-## Configuration
+## Values
 
-To get all available values in cloned `helm-charts` do:
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity rules |
+| autoscaling.enabled | bool | `false` | Whether to enable HPA |
+| autoscaling.maxReplicas | int | `10` | Maximum HPA replicas |
+| autoscaling.minReplicas | int | `1` | Minimum HPA replicas |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` | Target threshold of CPU utilization |
+| autoscaling.targetMemoryUtilizationPercentage | int | `80` | Target threshold of RAM utilization |
+| backend.affinity | object | `{}` |  |
+| backend.awsConfig.accountId | string | `nil` | AWS Account ID |
+| backend.awsConfig.region | string | `nil` | AWS Region |
+| backend.extraEnvVars | list | `[]` | Extra Environment Variables |
+| backend.logLevel | string | `"info"` |  |
+| backend.metrics.enabled | bool | `false` | Whether to enable prometheus metrics |
+| backend.network | string | `nil` | Name of a testnet |
+| backend.requestsPerPkHourly | int | `120` | Hourly rate limit per Mina node |
+| backend.storage.keyspace.awsKeyspaceName | string | `nil` | Name of AWS Keyspace |
+| backend.storage.local.path | string | `nil` | Path for storing submissions locally |
+| backend.storage.s3.awsBucketNameSuffix | string | `nil` | Buckets are named `awsConfig.AccountId`-`awsBucketNameSuffix` |
+| backend.verifySignatureDisabled | bool | `false` | Disable submission signature verification |
+| backend.whitelistConfig.column | string | `nil` | Google spreadsheet column name |
+| backend.whitelistConfig.enabled | bool | `false` | Whether to verify participants with Google sheet whitelist |
+| backend.whitelistConfig.sheet | string | `nil` | Google spreadsheet sheet name |
+| backend.whitelistConfig.spreadsheetId | string | `nil` | Google spreadsheet ID |
+| fullnameOverride | string | `""` | The full release name override |
+| image.pullPolicy | string | `"IfNotPresent"` | The pullPolicy used when pulling the image |
+| image.repository | string | `"673156464838.dkr.ecr.us-west-2.amazonaws.com/uptime-service-backend"` | The repository of the image |
+| image.tag | string | `"2.0.0rc5-cb6524c"` | The tag of the image. Overrides the image tag whose default is the chart appVersion. |
+| imagePullSecrets | list | `[]` | The secrets used to pull the image |
+| ingress.annotations | object | `{}` | Ingress Annotations |
+| ingress.className | string | `"alb"` | Ingress class name |
+| ingress.enabled | bool | `false` | Whether to enable ingress |
+| ingress.hosts | list | `[]` |  |
+| ingress.tls | list | `[]` |  |
+| nameOverride | string | `""` | The release name override |
+| nodeSelector | object | `{}` | Node selector labels |
+| podAnnotations | object | `{}` | Annotations to add to the pods |
+| podLabels | object | `{}` | The labels to add to the pods |
+| podSecurityContext | object | `{}` | The Pod Security Context |
+| replicaCount | int | `1` | The number of pods to be deployed for bot |
+| resources | object | `{}` | Resource limitations for the pods |
+| secret.gcpServiceAccount | string | `nil` | GCP service account json |
+| secret.keyspaceCert.content | string | `nil` | Certificate content |
+| secret.keyspaceCert.name | string | `nil` | Certificate file name(i.e. cert.crt) |
+| secret.keyspaceCert.override | bool | `false` | Whether to override default certificate |
+| securityContext | object | `{}` | The Security Context |
+| service.port | int | `8080` | Kubernetes Service port |
+| service.type | string | `"ClusterIP"` | Kubernetes Service type |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.automount | bool | `true` | Automatically mount a ServiceAccount's API credentials? |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `""` | If not set and create is true, a name is generated using the fullname template |
+| tolerations | list | `[]` | Tolerations |
 
-```bash
-helm show values ./uptime-service-backend
-```
-
-The following table lists the configurable parameters of the `uptime-service-backend` chart and its common default values.
-
-### Common parameters
-
-| Name                           | Description                                            | Value           |
-| ------------------------------ | ------------------------------------------------------ | --------------- |
-| `image.repository`               | `uptime-service-backend` docker image url                | `673156464838.dkr.ecr.us-west-2.amazonaws.com/block-producers-uptime` |
-| `image.tag`                      | Docker image tag                                       | `1.0.0itn1`       |
-| `image.pullPolicy`               | Docker image pull policy                               | `IfNotPresent`    |
-| `affinity`                       | Determines affinity https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity | `{}` |
-| `nodeSelector`                   | Override Node Selector                                 | `{}`              |
-| `tolerations`                    | Set Tolerations                                        | `[]`              |
-| `nameOverride`                   | Name override                                          | `""`              |
-| `fullnameOverride`               | Fullname override                                      | `""`              |
-| `podAnnotations`                 | Annotations to add to the pods                         | `{}`              |
-| `podSecurityContext`             | Pod Security Context                                   | `{}`              |
-| `securityContext`                | Security Context                                       | `{}`              |
-
-
-### Secrets
-
-| Name                           | Description                                            | Value           |
-| ------------------------------ | ------------------------------------------------------ | --------------- |
-| `secret.gcpServiceAccount`       | Json Content of GCP Service Account                    | `""`              |
-| `secret.keyspaceCert.override`   | Whether to override default certificate                | `false`           |
-| `secret.keyspaceCert.name`       | Name of certificate placed in `/uptime/certs`            | `""`              |
-| `secret.keyspaceCert.content`    | Contents of certificate used by AWS Keyspaces          | `""`              |
-
-### Service and Ingress
-
-| Name                           | Description                                            | Value           |
-| ------------------------------ | ------------------------------------------------------ | --------------- |
-| `service.type`                   | Kubernetes Service type                                | `ClusterIP`       |
-| `service.port`                   | Kubernetes Service port                                | `8080`            |
-| `ingress.enabled`                | Whether to enable ingress                              | `false`           |
-| `ingress.className`              | Ingress class name                                     | `alb`             |
-| `ingress.labels`                 | Ingress Labels                                         | `{}`              |
-| `ingress.annotations`            | Ingress Annotations                                    | `{}`              |
-| `ingress.hosts`                  | Ingress Hosts                                          | `[]`              |
-
-### Serviceaccount
-
-| Name                           | Description                                            | Value           |
-| ------------------------------ | ------------------------------------------------------ | --------------- |
-| `serviceAccount.create`          | Specifies whether a Service Account should be created  | `true`            |
-| `serviceaccount.annotations`     | K8s Service Account Annotations                        | `{}`              |
-
-### Resources and scaling
-
-| Name                           | Description                                            | Value           |
-| ------------------------------ | ------------------------------------------------------ | --------------- |
-| `replicaCount`                   | Amount of replicas to deploy                           | `1`               |
-| `resources.request.memory`       | Memory requested for the application pod               | `256Mi`           |
-| `resources.request.cpu`          | CPU resources requested for the application pod        | `500m`            |
-| `resources.limit.memory`         | Maximum memory allowed for the application pod         | `512Mi`           |
-| `resources.limit.cpu`            | Maximum CPU resources allowed for the application pod  | `1`               |
-| `autoscaling.enabled`            | Autoscaling toggle                                     | `false`           |
-| `autoscaling.minReplicas`        | Autoscaling minimum replicas                           | `1`               |
-| `autoscaling.maxReplicas`        | Autoscaling maximum replicas                           | `10`              |
-| `autoscaling.targetCPUUtilizationPercentage`| Autoscaling cpu utilization threshold in precentage| `80`       |
-| `autoscaling.targetMemoryUtilizationPercentage`| Autoscaling memory utilization threshold in precentage| `80` |
-
-### Application parameters
-
-| Name                           | Description                                            | Value           |
-| ------------------------------ | ------------------------------------------------------ | --------------- |
-| `backend.network`              | Testnet name                                           | `""`            |
-| `backend.requestsPerPkHourly`  | Number of requests accepted per hour                   | `1000`          |
-| `backend.verifySignatureDisabled`| Specifies if the backend signature verification is enabled or not| `false |
-| `backend.logLevel`             | Application log level                                  | `info`          |
-| `backend.metrics.enabled`      | Toggle for prometheus metrics                          | `false`         |
-| `backend.extraEnvVars`         | Environment Variables to pass to the container         | `[]`            |
-
-### Google spreadsheet to read whitelist from
-
-| Name                           | Description                                            | Value           |
-| ------------------------------ | ------------------------------------------------------ | --------------- |
-| `backend.whitelistConfig.enabled`| Whitelisting toggle. If enabled will configure other variables if not will omit| `false`|
-| `backend.whitelistConfig.spreadsheetId`| Google spreadsheet ID                            | `""`              |
-| `backend.whitelistConfig.sheet`  | Google sheet name                                      | `""`              |
-| `backend.whitelistConfig.column` | Google document                                        | `""`              |
-
-### AWS Account Parameters
-
-| Name                           | Description                                            | Value           |
-| ------------------------------ | ------------------------------------------------------ | --------------- |
-| `backend.awsConfig.accountId`    | AWS Account ID                                         | `""`  |
-| `backend.awsConfig.region`       | AWS Region                                             | `""`  |
-| `backend.awsConfig.accessKeyId`  | AWS Access Key ID                                      | `""`  |
-| `backend.awsConfig.secretAccessKey`| AWS Secret Access Key                                | `""`  |
-
-### Storage Backend Parameters
-
-> **Note:** Multiple storage types can be enabled.
-
-| Name                           | Description                                            | Value           |
-| ------------------------------ | ------------------------------------------------------ | --------------- |
-| `backend.storage.type`           | One of the 3 available types: `s3`,`keyspace` or `local`.    | `""`              |
-| `backend.storage.s3.awsBucketNameSuffix`| Buckets are named `awsAccountId`-`awsBucketNameSuffix`| `""`            |
-| `backend.storage.keyspace.awsKeyspaceName`| Name of AWS Keyspace program should be using  | `""`              |
-| `backend.storage.local.path`     | Local path to store data                               | `""`              |

--- a/uptime-service-backend/templates/deployment.yaml
+++ b/uptime-service-backend/templates/deployment.yaml
@@ -1,8 +1,3 @@
-# One of the authentication methods has to be provided
-{{- if not (and .Values.backend.awsConfig.accessKeyId .Values.backend.awsConfig.secretAccessKey) }}
-{{- required "Both .Values.backend.awsConfig.accessKeyId .Values.backend.awsConfig.secretAccessKey are required. Cannot authenticate without them" .Values.backend.awsConfig.accessKeyId -}}
-{{- end }}
-
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -75,10 +70,6 @@ spec:
             - name: AWS_SSL_CERTIFICATE_PATH
               value: /uptime/cert/{{ .Values.secret.keyspaceCert.name }}
             {{- end }}
-            - name: AWS_ACCESS_KEY_ID
-              value: {{ .Values.backend.awsConfig.accessKeyId | quote }}
-            - name: AWS_SECRET_ACCESS_KEY
-              value: {{ .Values.backend.awsConfig.secretAccessKey | quote }}
             - name: AWS_REGION
               value: {{ .Values.backend.awsConfig.region | quote }}
           volumeMounts:
@@ -126,10 +117,6 @@ spec:
             {{- end }}
             {{- end }}
             # AWS related variables
-            - name: AWS_ACCESS_KEY_ID
-              value: {{ .Values.backend.awsConfig.accessKeyId | quote }}
-            - name: AWS_SECRET_ACCESS_KEY
-              value: {{ .Values.backend.awsConfig.secretAccessKey | quote }}
             - name: AWS_REGION
               value: {{ .Values.backend.awsConfig.region | quote }}
             {{- if and .Values.backend.storage.s3 .Values.backend.storage.s3.awsBucketNameSuffix }}

--- a/uptime-service-backend/values.yaml
+++ b/uptime-service-backend/values.yaml
@@ -2,33 +2,46 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# Application specific values
+# -- The number of pods to be deployed for bot
+replicaCount: 1
+
 backend:
+  # -- Name of a testnet
   network:
   logLevel: info
+  # -- Disable submission signature verification
   verifySignatureDisabled: false
+  # -- Hourly rate limit per Mina node
   requestsPerPkHourly: 120
   affinity: {}
   whitelistConfig:
+    # -- Whether to verify participants with Google sheet whitelist
     enabled: false
+    # -- Google spreadsheet ID
     spreadsheetId:
+    # -- Google spreadsheet sheet name
     sheet:
+    # -- Google spreadsheet column name
     column:
   awsConfig:
-    roleSession:
+    # -- AWS Account ID
     accountId:
+    # -- AWS Region
     region:
-    accessKeyId:
-    secretAccessKey:
   storage:
     s3:
+      # -- Buckets are named `awsConfig.AccountId`-`awsBucketNameSuffix`
       awsBucketNameSuffix:
     keyspace:
+      # -- Name of AWS Keyspace
       awsKeyspaceName:
     local:
+      # -- Path for storing submissions locally
       path:
   metrics:
+    # -- Whether to enable prometheus metrics
     enabled: false
+  # -- Extra Environment Variables
   extraEnvVars: []
     # See Application's README(or source code).
     # - name: FOO
@@ -41,38 +54,53 @@ backend:
 
 
 secret:
+  # -- GCP service account json
   gcpServiceAccount:
   keyspaceCert:
+    # -- Whether to override default certificate
     override: false
+    # -- Certificate file name(i.e. cert.crt)
     name:
+    # -- Certificate content
     content:
 
 image:
+  # -- The repository of the image
   repository: 673156464838.dkr.ecr.us-west-2.amazonaws.com/uptime-service-backend
+  # -- The pullPolicy used when pulling the image
   pullPolicy: IfNotPresent
+  # -- The tag of the image. Overrides the image tag whose default is the chart appVersion.
   tag: "2.0.0rc5-cb6524c"
 
+# -- The secrets used to pull the image
 imagePullSecrets: []
+# -- The release name override
 nameOverride: ""
+# -- The full release name override
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
+  # -- Specifies whether a service account should be created
   create: true
-  # Automatically mount a ServiceAccount's API credentials?
+  # -- Automatically mount a ServiceAccount's API credentials?
   automount: true
-  # Annotations to add to the service account
+  # -- Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # -- The name of the service account to use.
+  # -- If not set and create is true, a name is generated using the fullname template
   name: ""
 
+# -- Annotations to add to the pods
 podAnnotations: {}
+
+# -- The labels to add to the pods
 podLabels: {}
 
+# -- The Pod Security Context
 podSecurityContext: {}
   # fsGroup: 2000
 
+# -- The Security Context
 securityContext: {}
   # capabilities:
   #   drop:
@@ -81,13 +109,19 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+
 service:
+  # -- Kubernetes Service type
   type: ClusterIP
+  # -- Kubernetes Service port
   port: 8080
 
 ingress:
+  # -- Whether to enable ingress
   enabled: false
+  # -- Ingress class name
   className: alb
+  # -- Ingress Annotations
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
@@ -102,17 +136,19 @@ ingress:
   #      - chart-example.local
 
 autoscaling:
+  # -- Whether to enable HPA
   enabled: false
+  # -- Minimum HPA replicas
   minReplicas: 1
+  # -- Maximum HPA replicas
   maxReplicas: 10
-  # targetCPUUtilizationPercentage: 80
+  # -- Target threshold of CPU utilization
+  targetCPUUtilizationPercentage: 80
+  # -- Target threshold of RAM utilization
   targetMemoryUtilizationPercentage: 80
 
+# -- Resource limitations for the pods
 resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   # limits:
   #   cpu: 100m
   #   memory: 128Mi
@@ -120,21 +156,11 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
-# Additional volumes on the output Deployment definition.
-volumes: []
-# - name: foo
-#   secret:
-#     secretName: mysecret
-#     optional: false
-
-# Additional volumeMounts on the output Deployment definition.
-volumeMounts: []
-# - name: foo
-#   mountPath: "/etc/foo"
-#   readOnly: true
-
+# -- Node selector labels
 nodeSelector: {}
 
+# -- Tolerations
 tolerations: []
 
+# -- Affinity rules
 affinity: {}


### PR DESCRIPTION
This change is mainly addressing AWS access key/id removal.
Since application changed. In our infra it works with service account annotations.
If someone would still want to run this with credentials, they could do that through extraEnvVars.

Additionally there were dangling values as well as outdated README, so I used the opportunity to convert to auto generated README.