### PR TITLE
PM-1699 fix US backend initcontainer creating condition

### DIFF
--- a/uptime-service-backend/templates/deployment.yaml
+++ b/uptime-service-backend/templates/deployment.yaml
@@ -30,8 +30,8 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "uptime-service-backend.serviceAccountName" . }}
+      {{- if .Values.backend.storage.keyspace.awsKeyspaceName }}
       initContainers:
-        {{- if .Values.backend.storage.keyspace }}
         - name: dbmigration
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           command: [ "db_migration" ]


### PR DESCRIPTION
this evaluates to true
```
{{- if .Values.backend.storage.keyspace }}
```
even if `backend.storage.keyspace.awsKeyspaceName` is not set.

If `awsKeyspaceName` is not set, init container should not be created 