### PR TITLE
PM-1556 GSS default image

### DIFF
--- a/gpt-survey-summarizer/README.md
+++ b/gpt-survey-summarizer/README.md
@@ -79,7 +79,7 @@ helmfile status
 | fullnameOverride | string | `""` | The full release name override |
 | image.pullPolicy | string | `"IfNotPresent"` | The pullPolicy used when pulling the image |
 | image.repository | string | `"673156464838.dkr.ecr.us-west-2.amazonaws.com/gpt-survey-summarizer"` | The repository of the image |
-| image.tag | string | `"0.2.0-4a6bee4"` | The tag of the iamge. Overrides the image tag whose default is the chart appVersion. |
+| image.tag | string | `""` | The tag of the iamge. Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | The secrets used to pull the image |
 | nameOverride | string | `""` | The release name override |
 | nodeSelector | object | `{}` | Node selector labels |

--- a/gpt-survey-summarizer/values.yaml
+++ b/gpt-survey-summarizer/values.yaml
@@ -60,7 +60,7 @@ image:
   # -- The pullPolicy used when pulling the image
   pullPolicy: IfNotPresent
   # -- The tag of the iamge. Overrides the image tag whose default is the chart appVersion.
-  tag: "0.2.0-4a6bee4"
+  tag: ""
 
 bot:
   # -- The number of pods to be deployed for bot


### PR DESCRIPTION
We are converting from the tag format `<semver>-<commit-sha>` to full semver.

Thus we should change the default image value.

This image is the same as the current deployed version only it was retagged.