### PR TITLE
PM 1971 support openmina helm charts for checksum and pvc

### DIFF
--- a/openmina-frontend/README.md
+++ b/openmina-frontend/README.md
@@ -50,7 +50,7 @@ helmfile status
 | fullnameOverride | string | `""` | Full name override |
 | image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | image.repository | string | `"openmina/frontend"` | The image repository |
-| image.tag | string | `"0.8.5"` | Overrides the image tag whose default is the chart appVersion. |
+| image.tag | string | `"0.8.3"` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | The secrets used to pull the image |
 | ingress.annotations | object | `{}` | The Ingress Annotations |
 | ingress.className | string | `""` | The Ingress Class Name to use |

--- a/openmina-frontend/values.yaml
+++ b/openmina-frontend/values.yaml
@@ -11,7 +11,7 @@ image:
   # -- The image pull policy
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion.
-  tag: "0.8.5"
+  tag: "0.8.3"
 
 # -- The secrets used to pull the image
 imagePullSecrets: []

--- a/openmina-node/README.md
+++ b/openmina-node/README.md
@@ -46,7 +46,7 @@ helmfile status
 | fullnameOverride | string | `""` | The full release name override |
 | image.pullPolicy | string | `"IfNotPresent"` | The pullPolicy used when pulling the image |
 | image.repository | string | `"openmina/openmina"` | The image repository |
-| image.tag | string | `"0.8.5"` | Overrides the image tag whose default is the chart appVersion. |
+| image.tag | string | `"0.8.3"` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | The secrets used to pull the image |
 | ingress.annotations | object | `{}` | The Ingress Annotations |
 | ingress.className | string | `""` | The Ingress Class Name to use |

--- a/openmina-node/values.yaml
+++ b/openmina-node/values.yaml
@@ -11,7 +11,7 @@ image:
   # -- The pullPolicy used when pulling the image
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion.
-  tag: "0.8.5"
+  tag: "0.8.3"
 
 # -- The secrets used to pull the image
 imagePullSecrets: []


### PR DESCRIPTION
- **PM-1971 - Openmina - Support for checksum and PVC**
- **PM-1971 - Openmina - Set default version to 0.8.3**
