### PR TITLE
PM-2113 - Fix next epoch non finalized catcher

### DIFF
--- a/mina-staking-ledgers-exporter/scripts/mina-staking-ledgers-exporter.py
+++ b/mina-staking-ledgers-exporter/scripts/mina-staking-ledgers-exporter.py
@@ -43,7 +43,7 @@ def main():
     try:
       process_staking_ledger(synced_pod, next_epoch, "next-epoch-ledger")
     except subprocess.CalledProcessError as e:
-      if "Ledger not found: next staking ledger is not finalized yet" in e.output:
+      if "Ledger not found: next staking ledger is not finalized yet" in e.stderr:
         logger.warning(f"Unable to process the next epoch {next_epoch} due to error: {e.output}, skipping further processing.")
       else:
         raise e


### PR DESCRIPTION
This is tricky to test, but that _should_ fix the issue the next time the exporter will run during a non-finalized epoch.