### PR TITLE
fix: fixed typos in gcp section for ease of understanding for developers

### DIFF
--- a/mina-daemon/README.md
+++ b/mina-daemon/README.md
@@ -57,8 +57,8 @@ helmfile status
 | deployment.storeBlocks.aws.uploadInterval | int | `900` | AWS upload interval |
 | deployment.storeBlocks.directory | string | `"/blocks"` | Block storage directory |
 | deployment.storeBlocks.enabled | bool | `false` | Enable block storage |
-| deployment.storeBlocks.gcp.bucket | string | `"mina_network_block_data"` | GCP bucket |
-| deployment.storeBlocks.gcp.enabled | bool | `false` | Enable GCP storage |
+| deployment.storeBlocks.gcp.bucket | string | `"mina_network_block_data"` | GCS bucket |
+| deployment.storeBlocks.gcp.enabled | bool | `false` | Enable GCP GCS storage |
 | deployment.storeBlocks.gcp.keyfile | string | `"{}"` | GCP keyfile |
 | deployment.storeBlocks.local.enabled | bool | `false` | Enable local storage |
 | deployment.storeBlocks.local.filename | string | `"precomputed_blocks.json"` | Local storage filename |

--- a/mina-daemon/values.yaml
+++ b/mina-daemon/values.yaml
@@ -49,9 +49,9 @@ deployment:
       # -- AWS upload interval
       uploadInterval: 900
     gcp:
-      # -- Enable GCP storage
+      # -- Enable GCP GCS storage
       enabled: false
-      # -- GCP bucket
+      # -- GCS bucket
       bucket: mina_network_block_data
       # -- GCP keyfile
       keyfile: "{}"


### PR DESCRIPTION
Fixed typos in `mina-daemon` `values.yaml` to provide better understanding within the file to prevent confusion for developers.