### PR TITLE
feat: add gcs option for mina-daemon charts

### DIFF
--- a/mina-daemon/scripts/gcs-blocks-uploader.sh
+++ b/mina-daemon/scripts/gcs-blocks-uploader.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env sh
+
+if [ -z "$SOURCE_DIR" ]; then
+    echo "The SOURCE_DIR environment variable is not set or is empty."
+    exit 1
+fi
+
+if [ -z "$GCS_BUCKET" ]; then
+    echo "The GCS_BUCKET environment variable is not set or is empty."
+    exit 1
+fi
+
+if [ -z "$UPLOAD_INTERVAL" ]; then
+    echo "The UPLOAD_INTERVAL environment variable is not set or is empty."
+    exit 1
+fi    
+
+if [ ! -z "$PREFIX" ]; then
+    GCS_BUCKET="${GCS_BUCKET}/${PREFIX}"
+    echo "Destination bucket is ${GCS_BUCKET}"
+fi
+
+cd "$SOURCE_DIR"
+
+while true; do
+    # Loop through local files
+    echo "Checking new blocks in $SOURCE_DIR"
+
+    blocks=$(ls | grep json)
+
+    # Check if there are any matching files
+    if [ -z "$blocks" ]; then
+        echo "No new blocks found in $SOURCE_DIR"
+    else
+        for local_file in $blocks; do
+            # Extract the filename without the path
+            block_name=$(basename "${local_file}")
+
+            # Check if the file exists in the GCS bucket
+            echo "Check if file ${block_name} exists in gs://${GCS_BUCKET}"
+            if gsutil ls "gs://${GCS_BUCKET}/${block_name}" 2>&1; then
+                echo "=> File ${block_name} already exists in GCS. Skipping."
+            
+            else
+            # Copy the file to GCS
+            gsutil cp "${local_file}" "gs://${GCS_BUCKET}/${block_name}"
+            echo "=> File ${block_name} copied to GCS."
+            fi
+            echo "Remove local block ${block_name}"
+            rm -rf "${local_file}"
+            echo ""
+        done
+    fi
+    echo "Sleeping for ${UPLOAD_INTERVAL} seconds..."
+    sleep $UPLOAD_INTERVAL
+done

--- a/mina-daemon/templates/configmap.yaml
+++ b/mina-daemon/templates/configmap.yaml
@@ -24,3 +24,6 @@ data:
 {{- end }}
   healthcheck.sh: |-
 {{ (.Files.Get "scripts/healthcheck.sh") | indent 4 }}
+{{- end }}
+s3-blocks-uploader.sh: |-
+{{ (.Files.Get "scripts/gcs-block-uploader.sh") | indent 4 }}

--- a/mina-daemon/templates/deployment.yaml
+++ b/mina-daemon/templates/deployment.yaml
@@ -616,3 +616,62 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+
+    {{ - if .Values.deployment.storeBlocks.gcp.enabled }}
+    - name: gcs-block-uploader
+      image: "{{ .Values.gcsBlocksUploader.image.repository }}:{{ .Values.gcsBlocksUploader.image.tag }}"
+      imagePullPolicy: {{ .Values.gcsBlocksUploader.image.pullPolicy }}
+      command: ["/bin/sh", "/scripts/gcs-blocks-uploader.sh"]
+      env:
+        - name: UPLOAD_INTERVAL
+          value: {{ .Values.deployment.storeBlocks.gcp.uploadInterval | quote }}
+        - name: SOURCE_DIR
+          value: {{ .Values.deployment.storeBlocks.directory | quote }}
+        - name: GCS_BUCKET
+          value: {{ .Values.deployment.storeBlocks.gcp.bucket | quote }}
+        {{- if .Values.deployment.storeBlocks.gcp.prefix }}
+        - name: PREFIX
+          value: {{ .Values.deployment.storeBlocks.gcp.prefix | quote }}
+        {{- end }}
+        {{- if not .Values.deployment.storeBlocks.gcp.useWorkloadIdentity }}
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: "/gcloud/keyfile.json"
+        {{- end }}
+      resources:
+        limits:
+          memory: {{ .Values.gcsBlocksUploader.resources.memoryLimit }}
+          cpu: {{ .Values.gcsBlocksUploader.resources.cpuLimit }}
+          {{- if .Values.gcsBlocksUploader.resources.ephemeralStorageLimit }}
+          ephemeral-storage: {{ .Values.gcsBlocksUploader.resources.ephemeralStorageLimit }}
+          {{- end }}
+        requests:
+          memory: {{ .Values.gcsBlocksUploader.resources.memoryRequest }}
+          cpu: {{ .Values.gcsBlocksUploader.resources.cpuRequest }}
+          {{- if .Values.gcsBlocksUploader.resources.ephemeralStorageRequest }}
+          ephemeral-storage: {{ .Values.gcsBlocksUploader.resources.ephemeralStorageRequest }}
+          {{- end }}
+      volumeMounts:
+        - name: {{ .Release.Name }}-scripts
+          mountPath: /scripts/gcs-blocks-uploader.sh
+          subPath: gcs-blocks-uploader.sh
+        - name: {{ .Release.Name }}-precomputed-blocks
+          mountPath: {{ .Values.deployment.storeBlocks.directory }}
+        {{- if not .Values.deployment.storeBlocks.gcp.useWorkloadIdentity }}
+        - name: {{ .Release.Name }}-gcloud-keyfile
+          mountPath: /gcloud
+          readOnly: true
+        {{- end }}
+      {{- end }}
+
+      volumes:
+      {{- if .Values.deployment.storeBlocks.gcp.enabled }}
+        {{- if not .Values.deployment.storeBlocks.gcp.useWorkloadIdentity }}
+      - name: {{ .Release.Name }}-gcloud-keyfile
+        secret:
+          secretName: {{ .Release.Name }}
+          defaultMode: 0400
+          items:
+            - key: gcloud-keyfile
+              path: keyfile.json
+        {{- end }}
+      {{- end }}

--- a/mina-daemon/templates/secret.yaml
+++ b/mina-daemon/templates/secret.yaml
@@ -15,3 +15,6 @@ data:
   {{- if or .Values.deployment.storeBlocks.gcp.enabled .Values.deployment.storeBlocks.aws.enabled }}
   gcloud-keyfile: {{ .Values.deployment.storeBlocks.gcp.keyfile | b64enc }}
   {{- end }}
+  {{- if or .Values.deployment.storeBlocks.gcp.enabled .Values.deployment.storeBlocks.gcp.enabled }}
+  gcloud-keyfile: {{ .Values.deployment.storeBlocks.gcp.keyfile | b64enc }}
+  {{- end }}


### PR DESCRIPTION
- Added Google Cloud Storage (GCS) option similar to S3 Block Uploader in `mina-daemon` chart to make it more accessible with GCP
- Planning to add Azure Blob Storage 